### PR TITLE
Snapshot test fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,15 +36,8 @@ jobs:
 
     - name: Test Raft with Snapshotting
       run: make test-snapshotting
-      continue-on-error: true
+      continue-on-error: false
 
     - name: Test Raft without Snapshotting
       run: make test
-      continue-on-error: true
-
-    - name: Check Test Results
-      run: |
-        if [ ${{ job.status }} == 'failure' ]; then
-          echo "Tests failed. Exiting with a non-zero status code."
-          exit 1
-        fi
+      continue-on-error: false

--- a/snapshot_storage_test.go
+++ b/snapshot_storage_test.go
@@ -23,7 +23,7 @@ func TestSnapshotStore(t *testing.T) {
 	validateSnapshot(t, snapshot1, &last1)
 
 	snapshot2 := NewSnapshot(2, 2, []byte("test2"))
-	require.NoError(t, snapshotStore.SaveSnapshot(snapshot1))
+	require.NoError(t, snapshotStore.SaveSnapshot(snapshot2))
 
 	last2, ok := snapshotStore.LastSnapshot()
 	require.True(t, ok)
@@ -31,7 +31,7 @@ func TestSnapshotStore(t *testing.T) {
 
 	snapshots := snapshotStore.ListSnapshots()
 
-	require.Len(t, snapshots, 2, "incorrect number of snapshots")
+	require.Len(t, snapshots, 2)
 
 	require.NoError(t, snapshotStore.Close())
 	require.NoError(t, snapshotStore.Open())
@@ -42,5 +42,5 @@ func TestSnapshotStore(t *testing.T) {
 	validateSnapshot(t, snapshot2, &last2)
 
 	snapshots = snapshotStore.ListSnapshots()
-	require.Len(t, snapshots, 2, "incorrect number of snapshots")
+	require.Len(t, snapshots, 2)
 }


### PR DESCRIPTION
This fixes a bug in the `build` workflow that allowed the workflow to pass when it should not. This also fixes a test that was failing in the `SnapshotStorage` test suite.