### PR TITLE
Read only ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 ![build](https://github.com/jmsadair/raft/actions/workflows/build.yml/badge.svg)
 
 # Raft
-This library provides a simple, easy-to-understand, and reliable implementation of [Raft](https://en.wikipedia.org/wiki/Raft_(algorithm)) using Go. Raft is a [consensus](https://en.wikipedia.org/wiki/Consensus_(computer_science)) protocol designed to manage replicated logs in a distributed system. Its purpose is to ensure fault-tolerant coordination and consistency among a group of nodes, making it suitable for building reliable systems. Potential use cases include distributed file systems, consistent key-value stores, and service discovery.
+
+This library provides a simple, easy-to-understand, and reliable implementation of [Raft](https://en.wikipedia.org/wiki/Raft_(algorithm)) using Go. Its current features include snapshotting and lease-based, read-only operrations. Raft is a [consensus](https://en.wikipedia.org/wiki/Consensus_(computer_science)) protocol designed to manage replicated logs in a distributed system. Its purpose is to ensure fault-tolerant coordination and consistency among a group of nodes, making it suitable for building reliable systems. Potential use cases include distributed file systems, consistent key-value stores, and service discovery.
 
 # Protocol Overview
+
 Raft is based on a leader-follower model, where one node is elected as the leader and coordinates the replication process. Time is divided into terms, and the leader is elected for each term through a leader election process. The leader receives client requests, which are then replicated to other nodes called followers. The followers maintain a log of all state changes, and the leader's responsibility is to ensure that all followers have consistent logs by sending them entries to append. Safety is guaranteed by requiring a majority of nodes to agree on the state changes, ensuring that no conflicting states are committed. 
 
 # Installation
+
 First, make sure you have Go `1.19` or a higher version installed on your system.
 You can download and install Go from the official [Go website](https://golang.org/). 
 
@@ -21,8 +24,8 @@ Once you have the library installed, you may refer to the [raft package referenc
 # Future Features
 
 The following features are currently in development or are intended to be added in the future:
+
 - Batched log writes to improve disk I/O
 - Membership changes
-- Read-only operations
 
 Other developers are encouraged to contribute to this project and pull requests are welcome.

--- a/lease.go
+++ b/lease.go
@@ -1,0 +1,47 @@
+package raft
+
+import "time"
+
+// lease represents a lease held by a leader in raft
+// The lease is considered valid until its expiration time, which is
+// calculated as the sum of the current time and the lease's duration
+// at the moment of lease renewal.
+//
+// The leader is allowed to serve read-only requests as long as its
+// lease is valid. When a lease expires, the leader must stop serving
+// read-only requests until the lease is renewed.
+//
+// Renewing the lease extends its validity by the duration period
+// from the current time. To check if a lease is valid at a given
+// moment, use the isValid method.
+//
+// Note that the lease mechanism depends on clock synchronization
+// between the nodes of the distributed system. Clock skew might
+// cause a node to incorrectly assume that its lease is still valid,
+// or conversely, that it has already ex
+type lease struct {
+	// Time at which the lease expires.
+	expiration time.Time
+
+	// The duration of a lease (typically an election timeout).
+	duration time.Duration
+}
+
+// newLease creates a new instance of a lease that will be valid
+// for the provided time duration. The newly created lease will not
+// be valid, it must be renewed first.
+func newLease(duration time.Duration) *lease {
+	return &lease{duration: duration, expiration: time.Now()}
+}
+
+// renew resets the expiration time of the lease to the current
+// time plus the duration of the lease.
+func (l *lease) renew() {
+	l.expiration = time.Now().Add(l.duration)
+}
+
+// isValid returns true if the current time is less than
+// the expiration time of the lease and false otherwise.
+func (l *lease) isValid() bool {
+	return time.Now().Before(l.expiration)
+}

--- a/lease_test.go
+++ b/lease_test.go
@@ -1,0 +1,30 @@
+package raft
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewLease checks that a new lease is not valid.
+// A lease should not be valid until renewed.
+func TestNewLease(t *testing.T) {
+	testLease := newLease(defaultElectionTimeout)
+	require.False(t, testLease.isValid())
+}
+
+// TestRenew checks that a lease is valid after being renewed.
+func TestRenew(t *testing.T) {
+	testLease := newLease(time.Duration(1 * time.Second))
+	testLease.renew()
+	require.True(t, testLease.isValid())
+}
+
+// TestExpires checks that a lease is no longer valid after
+// it has not been renewed.
+func TestExpires(t *testing.T) {
+	testLease := newLease(defaultElectionTimeout)
+	time.Sleep(defaultElectionTimeout)
+	require.False(t, testLease.isValid())
+}

--- a/options.go
+++ b/options.go
@@ -17,6 +17,10 @@ const (
 	minMaxEntriesPerRPC     = 50
 	maxMaxEntriesPerRPC     = 500
 	defaultMaxEntriesPerRPC = 100
+
+	minLeaseDuration     = time.Duration(25 * time.Millisecond)
+	maxLeaseDuration     = time.Duration(1000 * time.Millisecond)
+	defaultLeaseDuration = time.Duration(300 * time.Millisecond)
 )
 
 // Logger supports logging messages at the debug, info, warn, error, and fatal level.
@@ -66,6 +70,9 @@ type options struct {
 	// an AppendEntries RPC.
 	maxEntriesPerRPC int
 
+	// The duration that a lease remains valid upon renewal.
+	leaseDuration time.Duration
+
 	// A logger for debugging and important events.
 	logger Logger
 }
@@ -103,6 +110,21 @@ func WithMaxEntriesPerRPC(maxEntriesPerRPC int) Option {
 			return errors.New("maximum entries per RPC value is invalid")
 		}
 		options.maxEntriesPerRPC = maxEntriesPerRPC
+		return nil
+	}
+}
+
+// WithLeaseDuration sets the duration for which a lease remains valid upon
+// renewal. A longer lease duration generally corresponds to higher performance
+// of read-only operations but increases the likelihood that stale data is read.
+// Likewise, a shorter lease duration corresponds to lesser performance of read-only
+// operations but decreases the likelihood of stale data being read.
+func WithLeaseDuration(leaseDuration time.Duration) Option {
+	return func(options *options) error {
+		if leaseDuration < minLeaseDuration || leaseDuration > maxLeaseDuration {
+			return errors.New("lease duration is invalid")
+		}
+		options.leaseDuration = leaseDuration
 		return nil
 	}
 }

--- a/raft.go
+++ b/raft.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -10,9 +11,33 @@ import (
 )
 
 var (
-	errNotLeader = errors.New("server is not the leader")
-	errShutdown  = errors.New("server is shutdown")
+	errShutdown = errors.New("server is shutdown")
 )
+
+// NotLeaderError is an error returned when an operation is submitted to a
+// server, and it is not the leader. Only the leader may submit operations.
+type NotLeaderError struct {
+	// The ID of the server the operation was submitted to.
+	ServerID string
+
+	// The ID of the server that this server recognizes as the leader. Note that this may not always be accurate.
+	KnownLeader string
+}
+
+func (e NotLeaderError) Error() string {
+	return fmt.Sprintf("server %s is not the leader: knownLeader = %s", e.ServerID, e.KnownLeader)
+}
+
+// InvalidLeaseError is returned when a read-only operation is submitted but the lease expires or the server
+// loses leadership before it can be applied to the state machine.
+type InvalidLeaseError struct {
+	// The ID of the server that the operation was submitted to.
+	ServerID string
+}
+
+func (e InvalidLeaseError) Error() string {
+	return fmt.Sprintf("server %s does not have a valid lease", e.ServerID)
+}
 
 // State represents the current state of a Raft server.
 // A Raft server may either be shutdown, the leader, or a follower.
@@ -54,19 +79,24 @@ type Operation struct {
 	// The operation as bytes. The provided state machine should be capable
 	// of decoding these bytes.
 	Bytes []byte
+
+	// Indicates whether the operation is read-only. If it is, the log index
+	// and log term will not be valid as there is no log entry associated with
+	// the operation.
+	IsReadOnly bool
+
+	// The log entry index associated with the operation.
+	LogIndex uint64
+
+	// The log entry term associated with the operation.
+	LogTerm uint64
 }
 
 // OperationResponse is the response that is generated after applying
 // an operation to the state machine.
 type OperationResponse struct {
-	// The term of the log entry containing the applied operation.
-	Term uint64
-
-	// The index of the log entry containing the applied operation.
-	Index uint64
-
-	// The bytes of the operation applied to the state machine.
-	Operation []byte
+	// The operation applied to the state machine.
+	Operation Operation
 
 	// The response returned by the state machine after applying the operation.
 	Response interface{}
@@ -98,6 +128,9 @@ type Raft struct {
 	// The ID of this Raft instance.
 	id string
 
+	// The ID that Raft instance believes is the leader. Used to redirect clients.
+	leaderId string
+
 	// The configuration options for this Raft instance.
 	options options
 
@@ -109,6 +142,9 @@ type Raft struct {
 
 	// This contains the highest log entry known to be replicated on each sever.
 	matchIndex map[string]uint64
+
+	// A lease for the leader to serve read-only operations, must be nil if the server is not the leader.
+	lease *lease
 
 	// This stores and retrieves log entries in a durable manner.
 	log Log
@@ -130,7 +166,11 @@ type Raft struct {
 
 	// A channel for transferring applied log entries from the apply loop to the fsm loop for
 	// actual application to the state machine.
-	fsmCh chan *LogEntry
+	fsmCh chan *Operation
+
+	// This channel is used for transferring lease related errors from the fsm loop back to SubmitReadOnlyOperation
+	// function.
+	readOnlyErrCh chan error
 
 	// Notifies receivers that operation has been applied.
 	operationResponseCh chan<- OperationResponse
@@ -197,6 +237,9 @@ func NewRaft(id string, peers map[string]Peer, log Log, storage Storage, snapsho
 	if options.maxEntriesPerRPC == 0 {
 		options.maxEntriesPerRPC = defaultMaxEntriesPerRPC
 	}
+	if options.leaseDuration == 0 {
+		options.leaseDuration = defaultLeaseDuration
+	}
 
 	// Open the storage to recover persisted state.
 	if err := storage.Open(); err != nil {
@@ -248,7 +291,8 @@ func NewRaft(id string, peers map[string]Peer, log Log, storage Storage, snapsho
 		storage:             storage,
 		snapshotStorage:     snapshotStorage,
 		fsm:                 fsm,
-		fsmCh:               make(chan *LogEntry, 100),
+		fsmCh:               make(chan *Operation, 100),
+		readOnlyErrCh:       make(chan error),
 		operationResponseCh: responseCh,
 		currentTerm:         currentTerm,
 		votedFor:            votedFor,
@@ -296,12 +340,16 @@ func (r *Raft) Start() error {
 		}
 	}
 
-	r.wg.Add(5)
+	r.wg.Add(4)
 	go r.applyLoop()
-	go r.fsmLoop()
 	go r.electionLoop()
 	go r.heartbeatLoop()
 	go r.commitLoop()
+
+	// Do not increment the wait group for this go routine. This go routine is terminated
+	// independently after all other go routines are shut down to avoid a race where read-only
+	// operations are written to the fsm channel after is closed.
+	go r.fsmLoop()
 
 	r.options.logger.Infof("server %s started: electionTimeout = %v, heartbeatInterval = %v",
 		r.id, r.options.electionTimeout, r.options.heartbeatInterval)
@@ -327,6 +375,8 @@ func (r *Raft) Stop() error {
 	r.wg.Wait()
 	r.mu.Lock()
 
+	close(r.fsmCh)
+
 	for _, peer := range r.peers {
 		if err := peer.Disconnect(); err != nil {
 			r.options.logger.Errorf("server %s failed to disconnect from peer: %s", r.id, err.Error())
@@ -350,21 +400,21 @@ func (r *Raft) Stop() error {
 	return nil
 }
 
-// SubmitOperation accepts a operation from a client for replication and
+// SubmitOperation accepts an operation (as bytes) from a client for replication and
 // returns the log index assigned to the operation, the term assigned to the
 // operation, and an error if this server is not the leader. Note that submitting
-// a operation for replication does not guarantee replication if there are failures.
+// an operation for replication does not guarantee replication if there are failures.
 // Once the operation has been replicated and applied to the state machine, the response
 // will be sent over the provided response channel.
-func (r *Raft) SubmitOperation(operation Operation) (uint64, uint64, error) {
+func (r *Raft) SubmitOperation(operation []byte) (uint64, uint64, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if r.state != Leader {
-		return 0, 0, errNotLeader
+		return 0, 0, NotLeaderError{ServerID: r.id, KnownLeader: r.leaderId}
 	}
 
-	entry := NewLogEntry(r.log.NextIndex(), r.currentTerm, operation.Bytes)
+	entry := NewLogEntry(r.log.NextIndex(), r.currentTerm, operation)
 	if err := r.log.AppendEntry(entry); err != nil {
 		r.options.logger.Fatalf("server %s failed to append entry to log: %s", err.Error())
 	}
@@ -373,6 +423,40 @@ func (r *Raft) SubmitOperation(operation Operation) (uint64, uint64, error) {
 	r.options.logger.Debugf("server %s submitted operation: logEntry = %v", r.id, entry)
 
 	return entry.Index, entry.Term, nil
+}
+
+// SubmitReadOnlyOperation accepts an operation (as bytes) from a client and immediately
+// applies it to the state machine without replication if this server has a valid lease.
+// Consequently, read-only operations will generally be significantly more performant than
+// replicated operations. However, read-only operations may read stale or incorrect data
+// under certain conditions. If this server has an invalid lease, an error is returned. Otherwise,
+// nil is returned and the response will be sent over the provided response channel.
+func (r *Raft) SubmitReadOnlyOperation(operation []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// It is necessary to increment the wait group to avoid a race where an operation is written
+	// to the fsm channel after it is closed during the shutdown process.
+	r.wg.Add(1)
+	defer r.wg.Done()
+
+	if r.state != Leader {
+		return NotLeaderError{ServerID: r.id, KnownLeader: r.leaderId}
+	}
+
+	readOnlyOperation := &Operation{
+		Bytes:      operation,
+		IsReadOnly: true,
+	}
+
+	r.options.logger.Debugf("server %s submitted read-only operation: operation = %v", r.id, operation)
+
+	r.mu.Unlock()
+	r.fsmCh <- readOnlyOperation
+	err := <-r.readOnlyErrCh
+	r.mu.Lock()
+
+	return err
 }
 
 // Status returns the status of the Raft instance. The status includes
@@ -467,6 +551,9 @@ func (r *Raft) AppendEntries(request *AppendEntriesRequest, response *AppendEntr
 	// Update the time of last contact - note that this should be done even
 	// if the request is rejected due to having a non-matching previous log entry.
 	r.lastContact = time.Now()
+
+	// Update the ID of the server that this server recognizes as the leader.
+	r.leaderId = request.LeaderID
 
 	// If the request has a more up-to-date term, update current term and
 	// become a follower.
@@ -647,13 +734,14 @@ func (r *Raft) ListSnapshots() []Snapshot {
 // sendAppendEntriesToPeers sends an AppendEntries RPC to all peers concurrently.
 // Expects lock to be held.
 func (r *Raft) sendAppendEntriesToPeers() {
+	numResponses := 0
 	for _, peer := range r.peers {
-		go r.sendAppendEntries(peer)
+		go r.sendAppendEntries(peer, &numResponses)
 	}
 }
 
 // sendAppendEntries sends an AppendEntries RPC to the provided peer.
-func (r *Raft) sendAppendEntries(peer Peer) {
+func (r *Raft) sendAppendEntries(peer Peer, numResponses *int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -721,6 +809,15 @@ func (r *Raft) sendAppendEntries(peer Peer) {
 	if response.Term > r.currentTerm {
 		r.becomeFollower(response.Term)
 		return
+	}
+
+	// Renew the lease if the majority of peers have responded.
+	// Set the response counter to nil to prevent additional renewals during
+	// this round of heartbeats.
+	if numResponses != nil && r.hasQuorum(*numResponses) {
+		r.lease.renew()
+		numResponses = nil
+		r.options.logger.Debugf("server %s renewed its lease", r.id)
 	}
 
 	if !response.Success {
@@ -1014,7 +1111,6 @@ func (r *Raft) applyLoop() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	defer r.wg.Done()
-	defer close(r.fsmCh)
 
 	for r.state != Shutdown {
 		r.applyCond.Wait()
@@ -1027,10 +1123,17 @@ func (r *Raft) applyLoop() {
 				r.options.logger.Fatalf("server %s failed getting entry from log: %s", r.id, err.Error())
 			}
 
+			operation := &Operation{
+				Bytes:      entry.Data,
+				IsReadOnly: false,
+				LogIndex:   entry.Index,
+				LogTerm:    entry.Term,
+			}
+
 			// Warning: do not hold locks when sending on the response channel. May deadlock
 			// if the client is not listening.
 			r.mu.Unlock()
-			r.fsmCh <- entry
+			r.fsmCh <- operation
 			r.mu.Lock()
 
 			r.lastApplied++
@@ -1038,28 +1141,39 @@ func (r *Raft) applyLoop() {
 	}
 }
 
-// fsmLoop is a long-running loop that applies log entries to the state machine and sends responses to
+// fsmLoop is a long-running loop that applies operations to the state machine and sends responses to
 // operations over the response channel. If auto snapshotting is enabled, it will take a snapshot once
 // enough entries have been applied. This should be called when the Raft instance is started and ran
 // as a separate go routine.
 func (r *Raft) fsmLoop() {
-	defer r.wg.Done()
 	defer close(r.operationResponseCh)
 
-	for entry := range r.fsmCh {
-		// Apply the log entry to the state machine.
-		response := OperationResponse{
-			Index:     entry.Index,
-			Term:      entry.Term,
-			Operation: entry.Data,
-			Response:  r.fsm.Apply(entry),
+	for operation := range r.fsmCh {
+		response := OperationResponse{Operation: *operation}
+
+		// Ensure that the lease is valid before performing read-only operation.
+		// This check should be as close as possible to where the operation is
+		// actually applied to the state machine to reduce the risk of reading stale
+		// data.
+		if operation.IsReadOnly {
+			r.mu.Lock()
+			leaseValid := r.lease != nil && r.lease.isValid()
+			r.mu.Unlock()
+			if leaseValid {
+				r.readOnlyErrCh <- nil
+			} else {
+				r.readOnlyErrCh <- InvalidLeaseError{ServerID: r.id}
+				continue
+			}
 		}
+
+		response.Response = r.fsm.Apply(operation)
 
 		// Notify the client of the result.
 		r.operationResponseCh <- response
 
-		r.options.logger.Debugf("server %s applied operation: index = %d, term = %d",
-			r.id, entry.Index, entry.Term)
+		r.options.logger.Debugf("server %s applied operation: read-only = %v index = %d, term = %d",
+			r.id, operation.IsReadOnly, operation.LogIndex, operation.LogTerm)
 
 		// Take a snapshot of the state machine if necessary.
 		if r.fsm.NeedSnapshot() {
@@ -1085,6 +1199,7 @@ func (r *Raft) becomeLeader() {
 		r.nextIndex[peer.ID()] = r.log.LastIndex() + 1
 		r.matchIndex[peer.ID()] = 0
 	}
+	r.lease = newLease(r.options.leaseDuration)
 	r.sendAppendEntriesToPeers()
 	r.options.logger.Infof("server %s has entered the leader state: term = %d", r.id, r.currentTerm)
 }
@@ -1095,12 +1210,13 @@ func (r *Raft) becomeFollower(term uint64) {
 	r.state = Follower
 	r.currentTerm = term
 	r.votedFor = ""
+	r.lease = nil
 	r.persistTermAndVote()
 	r.options.logger.Infof("server %s has entered the follower state: term = %d", r.id, r.currentTerm)
 }
 
 // hasQuorum indicates whether the provided count constitutes a majority
-// of the cluster. Expects lock to held.
+// of the cluster. Expects lock to be held.
 func (r *Raft) hasQuorum(count int) bool {
 	return count > len(r.peers)/2
 }

--- a/raft.go
+++ b/raft.go
@@ -814,6 +814,7 @@ func (r *Raft) sendAppendEntries(peer Peer, numResponses *int) {
 	// Renew the lease if the majority of peers have responded.
 	// Set the response counter to nil to prevent additional renewals during
 	// this round of heartbeats.
+	*numResponses += 1
 	if numResponses != nil && r.hasQuorum(*numResponses) {
 		r.lease.renew()
 		numResponses = nil
@@ -1172,7 +1173,7 @@ func (r *Raft) fsmLoop() {
 		// Notify the client of the result.
 		r.operationResponseCh <- response
 
-		r.options.logger.Debugf("server %s applied operation: read-only = %v index = %d, term = %d",
+		r.options.logger.Debugf("server %s applied operation: read-only = %v, index = %d, term = %d",
 			r.id, operation.IsReadOnly, operation.LogIndex, operation.LogTerm)
 
 		// Take a snapshot of the state machine if necessary.

--- a/raft.go
+++ b/raft.go
@@ -24,6 +24,9 @@ type NotLeaderError struct {
 	KnownLeader string
 }
 
+// This function implements the error interface for the NotLeaderError type.
+// It formats and returns an error message indicating that the server with
+// the ID e.ServerID is not the leader, and the known leader is e.KnownLeader.
 func (e NotLeaderError) Error() string {
 	return fmt.Sprintf("server %s is not the leader: knownLeader = %s", e.ServerID, e.KnownLeader)
 }
@@ -35,6 +38,9 @@ type InvalidLeaseError struct {
 	ServerID string
 }
 
+// This function implements the error interface for the InvalidLeaseError type.
+// It formats and returns an error message indicating that the server with
+// the ID e.ServerID does not have a valid lease.
 func (e InvalidLeaseError) Error() string {
 	return fmt.Sprintf("server %s does not have a valid lease", e.ServerID)
 }

--- a/raft.go
+++ b/raft.go
@@ -814,11 +814,13 @@ func (r *Raft) sendAppendEntries(peer Peer, numResponses *int) {
 	// Renew the lease if the majority of peers have responded.
 	// Set the response counter to nil to prevent additional renewals during
 	// this round of heartbeats.
-	*numResponses += 1
-	if numResponses != nil && r.hasQuorum(*numResponses) {
-		r.lease.renew()
-		numResponses = nil
-		r.options.logger.Debugf("server %s renewed its lease", r.id)
+	if numResponses != nil {
+		*numResponses += 1
+		if r.hasQuorum(*numResponses) {
+			r.lease.renew()
+			numResponses = nil
+			r.options.logger.Debugf("server %s renewed its lease", r.id)
+		}
 	}
 
 	if !response.Success {

--- a/server.go
+++ b/server.go
@@ -120,12 +120,22 @@ func (s *Server) IsStarted() bool {
 	return s.server != nil
 }
 
-// SubmitOperation submits a operation to the server for processing.
+// SubmitOperation submits an operation (as bytes) to the server for processing.
 // It forwards the operation to the underlying Raft instance for handling
 // and returns the index and term assigned to the operation, as well as
 // an error if submitting the operation failed.
-func (s *Server) SubmitOperation(operation Operation) (uint64, uint64, error) {
+func (s *Server) SubmitOperation(operation []byte) (uint64, uint64, error) {
 	return s.raft.SubmitOperation(operation)
+}
+
+// SubmitReadOnlyOperation submits an operation (as bytes) to the server for
+// processing. It forwards the operation to the underlying Raft instance for handling
+// and returns an error if submitting the operation failed. Read-only operations are
+// generally much more performant than standard, replicated operations. However,
+// be warned that read-only operations are NOT safe. It is possible that stale or
+// incorrect data may be returned under certain conditions.
+func (s *Server) SubmitReadOnlyOperation(operation []byte) error {
+	return s.raft.SubmitReadOnlyOperation(operation)
 }
 
 // ListSnapshots returns an array of all the snapshots that the underlying

--- a/server_test.go
+++ b/server_test.go
@@ -159,11 +159,11 @@ func TestConcurrentSubmit(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Simulates a client submitting operations.
-	client := func(operations []Operation, readyCh chan interface{}) {
+	client := func(operations [][]byte, readyCh chan interface{}) {
 		defer wg.Done()
 		<-readyCh
-		for _, command := range operations {
-			cluster.submit(command, false, false, 5)
+		for _, operation := range operations {
+			cluster.submit(operation, false, false, 5)
 		}
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -619,3 +619,90 @@ func TestAllCrash(t *testing.T) {
 		cluster.submit(operations[i], true, false, 5)
 	}
 }
+
+// TestBasicReadOnly checks that a read-only operation submitted under normal conditions
+// returns the latest state from the state machine without error.
+func TestBasicReadOnly(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 1*time.Second)
+
+	cluster := newCluster(t, 5, snapshotting, snapshotSize)
+
+	cluster.startCluster()
+	defer cluster.stopCluster()
+
+	// Wait for a leader and submit some operations.
+	cluster.checkLeaders(false)
+	operations := makeOperations(1)
+	cluster.submit(operations[0], false, false, 5)
+	cluster.submitReadOnly(false, false)
+}
+
+// TestSingleServerReadOnly checks that a read-only operations are successful in the single server case.
+func TestSingleServerReadOnly(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 1*time.Second)
+
+	cluster := newCluster(t, 1, snapshotting, snapshotSize)
+
+	cluster.startCluster()
+	defer cluster.stopCluster()
+
+	// Wait for a leader and submit some operations.
+	cluster.checkLeaders(false)
+	operations := makeOperations(10)
+	for _, command := range operations {
+		cluster.submit(command, false, false, 1)
+	}
+
+	// Make sure read-only operation is successful.
+	cluster.submitReadOnly(false, false)
+}
+
+// TestReadOnlyFail checks that a read-only operation submitted when a leader has not received heartbeats
+// from a majority of the partition is rejected.
+func TestReadOnlyFail(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 1*time.Second)
+
+	cluster := newCluster(t, 3, snapshotting, snapshotSize)
+
+	cluster.startCluster()
+	defer cluster.stopCluster()
+
+	// Wait for a leader.
+	leader := cluster.checkLeaders(false)
+
+	// Disconnect the other two servers in the cluster.
+	cluster.disconnectServer((leader + 1) % 3)
+	cluster.disconnectServer((leader + 2) % 3)
+
+	// Give the lease some time to expire.
+	time.Sleep(defaultLeaseDuration)
+
+	// Make sure the read-only operation fails.
+	cluster.submitReadOnly(true, true)
+}
+
+// TestReadOnlyDisconnect checks that a new leader will renew its lease
+// after the old one is disconnected, thereby allowing successful read-only
+// operations.
+func TestReadOnlyDisconnect(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 1*time.Second)
+
+	cluster := newCluster(t, 5, snapshotting, snapshotSize)
+
+	cluster.startCluster()
+	defer cluster.stopCluster()
+
+	// Submit some operations to the initial leader.
+	leader := cluster.checkLeaders(false)
+	operations := makeOperations(10)
+	for _, command := range operations {
+		cluster.submit(command, false, false, 5)
+	}
+
+	// Disconnect the leader and wait for a new one.
+	cluster.disconnectServer(leader)
+	cluster.checkLeaders(false)
+
+	// Check that read-only operation is successful.
+	cluster.submitReadOnly(false, false)
+}

--- a/state_machine.go
+++ b/state_machine.go
@@ -3,8 +3,8 @@ package raft
 // StateMachine is an interface representing a replicated state machine.
 // The implementation must be concurrent safe.
 type StateMachine interface {
-	// Apply applies the given log entry to the state machine.
-	Apply(entry *LogEntry) interface{}
+	// Apply applies the given Operation to the state machine.
+	Apply(operation *Operation) interface{}
 
 	// Snapshot returns a snapshot of the current state of the state machine.
 	// The bytes contained in the snapshot must be serialized in a way that

--- a/testing.go
+++ b/testing.go
@@ -549,6 +549,10 @@ func (tc *testCluster) applyLoop(index int) {
 		if response.Operation.LogIndex > tc.lastApplied[index]+1 {
 			tc.checkSnapshot(index, response)
 		} else if response.Operation.IsReadOnly {
+			// If it is a read-only operation, the best that can be done is to check
+			// that the state that is read is the same as the most recent state on
+			// this server. Recall that read-only operations make no guarantees about
+			// reading up-to-date data.
 			tc.checkReadOnlyOperation(index, response)
 		} else {
 			tc.checkLogs(index, response)


### PR DESCRIPTION
This adds support for an initial version of lease-based, read-only operations. The client may now specify a lease duration in the options provided to `raft` if they so choose (the default is the election timeout). Furthermore, tests were added for read-only operations. These tests are not all that comprehensive due to the fact that read-only operations make no guarantee about reading up-to-data, but they demonstrate that they work without errors. More comprehensive testing should be done by creating an example application with `raft`. Finally, the package documentation was updated to reflect this new feature.