### PR TITLE
Fixed failing read-only test

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -703,6 +703,9 @@ func TestReadOnlyDisconnect(t *testing.T) {
 	cluster.disconnectServer(leader)
 	cluster.checkLeaders(false)
 
+	// Give the leader a bit of time to make sure its lease gets renewed.
+	time.Sleep(defaultElectionTimeout)
+
 	// Check that read-only operation is successful.
 	cluster.submitReadOnly(false, false)
 }


### PR DESCRIPTION
Fixed `TestReadOnlyDisconnect` by giving it more time to renew the lease.