### PR TITLE
Refactoring

### DIFF
--- a/lease.go
+++ b/lease.go
@@ -18,7 +18,7 @@ import "time"
 // Note that the lease mechanism depends on clock synchronization
 // between the nodes of the distributed system. Clock skew might
 // cause a node to incorrectly assume that its lease is still valid,
-// or conversely, that it has already ex
+// or conversely, that it has already expired.
 type lease struct {
 	// Time at which the lease expires.
 	expiration time.Time

--- a/log.go
+++ b/log.go
@@ -103,7 +103,8 @@ type persistentLog struct {
 	path string
 }
 
-func newPersistentLog(path string) *persistentLog {
+// NewLog creates a new instance of Log at the provided path.
+func NewLog(path string) Log {
 	return &persistentLog{path: path}
 }
 

--- a/log_test.go
+++ b/log_test.go
@@ -9,7 +9,7 @@ import (
 func TestAppendEntries(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := tmpDir + "/test-log.bin"
-	log := newPersistentLog(path)
+	log := NewLog(path)
 
 	require.NoError(t, log.Open())
 	require.NoError(t, log.Replay())
@@ -60,7 +60,7 @@ func TestAppendEntries(t *testing.T) {
 func TestTruncate(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := tmpDir + "/test-log.bin"
-	log := newPersistentLog(path)
+	log := NewLog(path)
 
 	require.NoError(t, log.Open())
 	require.NoError(t, log.Replay())
@@ -111,7 +111,7 @@ func TestTruncate(t *testing.T) {
 func TestCompact(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := tmpDir + "/test-log.bin"
-	log := newPersistentLog(path)
+	log := NewLog(path)
 
 	require.NoError(t, log.Open())
 	require.NoError(t, log.Replay())
@@ -178,7 +178,7 @@ func TestCompact(t *testing.T) {
 func TestDiscard(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := tmpDir + "/test-log.bin"
-	log := newPersistentLog(path)
+	log := NewLog(path)
 
 	require.NoError(t, log.Open())
 	require.NoError(t, log.Replay())
@@ -210,7 +210,7 @@ func TestDiscard(t *testing.T) {
 func TestContains(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := tmpDir + "/test-log.bin"
-	log := newPersistentLog(path)
+	log := NewLog(path)
 
 	require.NoError(t, log.Open())
 	require.NoError(t, log.Replay())

--- a/peer.go
+++ b/peer.go
@@ -60,9 +60,9 @@ type peer struct {
 	mu sync.RWMutex
 }
 
-// newPeer creates a new instance of a peer with
-// the provided ID and network address.
-func newPeer(id string, address net.Addr) *peer {
+// NewPeer creates a new Peer instance. The function establishes a gRPC client
+// for making Raft protocol calls to the peer. This function is concurrent-safe.
+func NewPeer(id string, address net.Addr) Peer {
 	return &peer{id: id, address: address}
 }
 

--- a/peer.go
+++ b/peer.go
@@ -21,6 +21,9 @@ type Peer interface {
 	// ID returns the ID of the peer.
 	ID() string
 
+	// Address returns the network address of the peer.
+	Address() net.Addr
+
 	// Connect establishes a connection with the peer.
 	Connect() error
 

--- a/raft.go
+++ b/raft.go
@@ -148,8 +148,8 @@ type Protocol interface {
 	// and an error if the operation failed to be added.
 	SubmitOperation(operation []byte) (uint64, uint64, error)
 
-	// SubmitReadOnlyOperation takes a byte array representing a read-only operation and
-	// adds it to the protocol's log. It returns an error if the operation failed to be added.
+	// SubmitReadOnlyOperation takes a byte array representing a read-only operation and applies
+	// it to the state machine without adding it to the protocol's log.
 	SubmitReadOnlyOperation(operation []byte) error
 
 	// Status returns the current status of the protocol. The returned status includes information

--- a/raft.go
+++ b/raft.go
@@ -126,8 +126,53 @@ type Status struct {
 	State State
 }
 
-// Raft represents the consensus module in the Raft architecture, a distributed consensus algorithm
-// designed for fault-tolerant systems. This implementation of Raft should be utilized as the internal
+// Protocol represents an abstraction of the raft consensus protocol.
+// The raft protocol is a distributed consensus algorithm designed for fault-tolerant systems.
+// It provides functions to start and stop the protocol, submit operations, check the status and manage snapshots.
+type Protocol interface {
+	// Start initializes the consensus protocol and prepares it to receive commands.
+	// It may involve establishing network connections, allocating resources etc.
+	// Returns error if the initialization fails.
+	Start() error
+
+	// Stop shuts down the consensus protocol safely. It may involve releasing resources,
+	// closing network connections etc. Returns error if the shutdown fails.
+	Stop() error
+
+	// SubmitOperation takes a byte array representing an operation and adds it to the
+	// protocol's log. It returns the log index and term where the operation was stored,
+	// and an error if the operation failed to be added.
+	SubmitOperation(operation []byte) (uint64, uint64, error)
+
+	// SubmitReadOnlyOperation takes a byte array representing a read-only operation and
+	// adds it to the protocol's log. It returns an error if the operation failed to be added.
+	SubmitReadOnlyOperation(operation []byte) error
+
+	// Status returns the current status of the protocol. The returned status includes information
+	// like the current term, whether the protocol is a leader, follower or candidate, and more.
+	Status() Status
+
+	// RequestVote handles vote requests from other nodes during elections. It takes a vote request
+	// and fills the response with the result of the vote. It returns an error if the vote request
+	// fails to be processed.
+	RequestVote(request *RequestVoteRequest, response *RequestVoteResponse) error
+
+	// AppendEntries handles log replication requests from the leader. It takes a request to append
+	// entries and fills the response with the result of the append operation. It returns an error
+	// if the append operation fails.
+	AppendEntries(request *AppendEntriesRequest, response *AppendEntriesResponse) error
+
+	// InstallSnapshot handles snapshot installation requests from the leader. It takes a request to
+	// install a snapshot and fills the response with the result of the installation. It returns an
+	// error if the snapshot installation process fails.
+	InstallSnapshot(request *InstallSnapshotRequest, response *InstallSnapshotResponse) error
+
+	// ListSnapshots returns a list of all snapshots currently stored by the protocol.
+	// Snapshots are used for log compaction and to bring new servers up to date.
+	ListSnapshots() []Snapshot
+}
+
+// Raft implements the Protocol interface. This implementation of Raft should be utilized as the internal
 // logic for an actual server, as it solely encapsulates the core functionality of Raft and cannot operate
 // as a standalone server.
 type Raft struct {

--- a/raft.go
+++ b/raft.go
@@ -2,6 +2,7 @@ package raft
 
 import (
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -112,6 +113,9 @@ type OperationResponse struct {
 type Status struct {
 	// The ID of the Raft instance.
 	ID string
+
+	// The Address of the Raft instance.
+	Address net.Addr
 
 	// The current term.
 	Term uint64
@@ -511,13 +515,14 @@ func (r *Raft) SubmitReadOnlyOperation(operation []byte) error {
 }
 
 // Status returns the status of the Raft instance. The status includes
-// the ID, term, commit index, last applied index, and state.
+// the ID, address, term, commit index, last applied index, and state.
 func (r *Raft) Status() Status {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	return Status{
 		ID:          r.id,
+		Address:     r.peers[r.id].Address(),
 		Term:        r.currentTerm,
 		CommitIndex: r.commitIndex,
 		LastApplied: r.lastApplied,

--- a/raft_test.go
+++ b/raft_test.go
@@ -8,7 +8,7 @@ import (
 // TestNewRaft checks that a newly created raft with no provided options does not have any persisted state and
 // has the default options.
 func TestNewRaft(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -32,7 +32,7 @@ func TestNewRaft(t *testing.T) {
 // TestAppendEntriesSuccess checks that raft handles a basic AppendEntries request that should be successful
 // correctly.
 func TestAppendEntriesSuccess(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -65,7 +65,7 @@ func TestAppendEntriesSuccess(t *testing.T) {
 // the log entries in a request are conflicting (a log entry in the request has a different term than a log
 // entry at the same index in the log).
 func TestAppendEntriesConflictSuccess(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -107,7 +107,7 @@ func TestAppendEntriesConflictSuccess(t *testing.T) {
 // TestAppendEntriesLeaderStepDownSuccess checks that a raft instance in the leader state correctly steps down to the
 // follower state when it receives an AppendEntries request with a greater term than its own.
 func TestAppendEntriesLeaderStepDownSuccess(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -136,7 +136,7 @@ func TestAppendEntriesLeaderStepDownSuccess(t *testing.T) {
 // TestAppendEntriesOutOfDateTermFailure checks that an AppendEntries request received that has a term less than
 // the term of server that received it is rejected.
 func TestAppendEntriesOutOfDateTermFailure(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -160,7 +160,7 @@ func TestAppendEntriesOutOfDateTermFailure(t *testing.T) {
 // TestAppendEntriesPrevLogIndexFailure checks that an AppendEntries request is rejected when the log does not contain
 // an entry at the previous log index whose term match the previous log term.
 func TestAppendEntriesPrevLogIndexFailure(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -187,7 +187,7 @@ func TestAppendEntriesPrevLogIndexFailure(t *testing.T) {
 // TestAppendEntriesShutdownFailure checks that an error is returned when an AppendEntries request is received
 // by a server in the shutdown state.
 func TestAppendEntriesShutdownFailure(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -206,7 +206,7 @@ func TestAppendEntriesShutdownFailure(t *testing.T) {
 
 // TestRequestVoteSuccess checks that raft handles a RequestVote request that should be successful correctly.
 func TestRequestVoteSuccess(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -231,7 +231,7 @@ func TestRequestVoteSuccess(t *testing.T) {
 // TestRequestVoteLeaderStepDownSuccess checks that a raft instance in the leader state correctly steps down to the
 // follower state when it receives an AppendEntries request with a greater term than its own.
 func TestRequestVoteLeaderStepDownSuccess(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -258,7 +258,7 @@ func TestRequestVoteLeaderStepDownSuccess(t *testing.T) {
 // TestRequestVoteAlreadyVotedSuccess checks that a raft instance that receives a RequestVote request from a server
 // that it already voted for grants it vote again.
 func TestRequestVoteAlreadyVotedSuccess(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -281,7 +281,7 @@ func TestRequestVoteAlreadyVotedSuccess(t *testing.T) {
 // TestRequestVoteAlreadyVotedFailure checks that a raft instance that receives a RequestVote request from a different
 // server after it already voted for another server refuses to grant its vote.
 func TestRequestVoteAlreadyVotedFailure(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -306,7 +306,7 @@ func TestRequestVoteAlreadyVotedFailure(t *testing.T) {
 // TestRequestVoteOutOfDateTermFailure checks that a RequestVote request received that has a term less than
 // the term of server that received it is rejected.
 func TestRequestVoteOutOfDateTermFailure(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -331,7 +331,7 @@ func TestRequestVoteOutOfDateTermFailure(t *testing.T) {
 // TestRequestVoteOutOfDateLogFailure checks that a RequestVote request received from a server with an out-of-date
 // log is rejected.
 func TestRequestVoteOutOfDateLogFailure(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -359,7 +359,7 @@ func TestRequestVoteOutOfDateLogFailure(t *testing.T) {
 // TestRequestVoteShutdownFailure checks that a RequestVote request received by a server in the shutdown state
 // is rejected and an error is returned.
 func TestRequestVoteShutdownFailure(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -378,7 +378,7 @@ func TestRequestVoteShutdownFailure(t *testing.T) {
 // TestInstallSnapshotSuccess checks that raft handles a basic InstallSnapshot request that should be successful
 // correctly.
 func TestInstallSnapshotSuccess(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -423,7 +423,7 @@ func TestInstallSnapshotSuccess(t *testing.T) {
 // TestInstallSnapshotDiscardSuccess checks that a server discards its log entries when it receives an InstallSnapshot
 // request if it does not have an entry at the last included index.
 func TestInstallSnapshotDiscardSuccess(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -473,7 +473,7 @@ func TestInstallSnapshotDiscardSuccess(t *testing.T) {
 // request with a last included index that this server has a log entry for and the that last included term
 // matches the term of that entry.
 func TestInstallSnapshotCompactSuccess(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -523,7 +523,7 @@ func TestInstallSnapshotCompactSuccess(t *testing.T) {
 // TestInstallSnapshotLeaderStepDownSuccess checks that a raft instance in the leader state correctly steps down to the
 // follower state when it receives an InstallSnapshot request with a greater term than its own.
 func TestInstallSnapshotLeaderStepDownSuccess(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)
@@ -555,7 +555,7 @@ func TestInstallSnapshotLeaderStepDownSuccess(t *testing.T) {
 // TestInstallSnapshotOutOfDateTermFailure checks that a InstallSnapshot request received that has a term less than
 // the term of server that received it is rejected.
 func TestInstallSnapshotOutOfDateTermFailure(t *testing.T) {
-	args := makeRaftArgs(t, false, 0)
+	args := makeDefaultRaftArgs(t, false, 0)
 
 	raft, err := NewRaft(args.id, args.peers, args.log, args.storage, args.snapshotStorage,
 		args.stateMachine, args.responseCh)

--- a/server.go
+++ b/server.go
@@ -39,14 +39,14 @@ func NewServer(id string, peers map[string]string, fsm StateMachine, logPath str
 		if err != nil {
 			return nil, errors.WrapError(err, "failed to resolve TCP address: address = %s", address)
 		}
-		grpcPeers[peer] = newPeer(peer, tcpAddr)
+		grpcPeers[peer] = NewPeer(peer, tcpAddr)
 		if peer == id {
 			listenInterface = tcpAddr
 		}
 	}
 
 	// Create log with protobuf encoding and decoding at the provided path.
-	log := newPersistentLog(logPath)
+	log := NewLog(logPath)
 
 	// Create storage with protobuf encoding and decoding at the provided path.
 	storage := newPersistentStorage(storagePath)

--- a/server.go
+++ b/server.go
@@ -15,56 +15,19 @@ import (
 // and fault tolerance.
 type Server struct {
 	pb.UnimplementedRaftServer
-	id              string
 	listenInterface net.Addr
 	listener        net.Listener
 	server          *grpc.Server
-	raft            *Raft
+	raft            Protocol
 	wg              sync.WaitGroup
 }
 
-// NewServer creates a new instance of a Server with the provided ID. The provided peers are the peers that will make up the cluster, including
-// the ID and network address of this server. The log path, storage path, and snapshot path specify the locations where the underlying Raft
-// instance persists its state. If the state is already persisted at these paths, it will be read into memory and Raft will be initialized with that state.
-// Otherwise, new files will be created at those paths. Responses from the state machine after applying an operation will be sent over the provided
-// response channel. The response channel must be monitored; otherwise, the server may be blocked.
-func NewServer(id string, peers map[string]string, fsm StateMachine, logPath string, storagePath string, snapshotPath string,
-	responseCh chan<- OperationResponse, opts ...Option) (*Server, error) {
-	var listenInterface net.Addr
-
-	// Create peers.
-	grpcPeers := make(map[string]Peer, len(peers))
-	for peer, address := range peers {
-		tcpAddr, err := net.ResolveTCPAddr("tcp", address)
-		if err != nil {
-			return nil, errors.WrapError(err, "failed to resolve TCP address: address = %s", address)
-		}
-		grpcPeers[peer] = NewPeer(peer, tcpAddr)
-		if peer == id {
-			listenInterface = tcpAddr
-		}
-	}
-
-	// Create log with protobuf encoding and decoding at the provided path.
-	log := NewLog(logPath)
-
-	// Create storage with protobuf encoding and decoding at the provided path.
-	storage := newPersistentStorage(storagePath)
-
-	// Create snapshot storage with protobuf encoding and decoding at the provided path.
-	snapshotStorage := newPersistentSnapshotStorage(snapshotPath)
-
-	raft, err := NewRaft(id, grpcPeers, log, storage, snapshotStorage, fsm, responseCh, opts...)
-	if err != nil {
-		return nil, errors.WrapError(err, "failed to create a raft server: ID = %s", id)
-	}
-
+// NewServer creates a new instance of a Server with a raft instance that satisfies the Protocol interface.
+func NewServer(raft Protocol) (*Server, error) {
 	server := &Server{
-		id:              id,
-		listenInterface: listenInterface,
+		listenInterface: raft.Status().Address,
 		raft:            raft,
 	}
-
 	return server, nil
 }
 

--- a/snapshot_storage.go
+++ b/snapshot_storage.go
@@ -68,9 +68,9 @@ type persistentSnapshotStorage struct {
 	file *os.File
 }
 
-// newPersistentSnapshotStorage creates a new instance of PersistentSnapshotStorage at the
+// NewSnapshotStorage creates a new instance of SnapshotStorage at the
 // provided path.
-func newPersistentSnapshotStorage(path string) *persistentSnapshotStorage {
+func NewSnapshotStorage(path string) SnapshotStorage {
 	return &persistentSnapshotStorage{path: path}
 }
 

--- a/snapshot_storage_test.go
+++ b/snapshot_storage_test.go
@@ -9,7 +9,7 @@ import (
 func TestSnapshotStore(t *testing.T) {
 	tmpDir := t.TempDir()
 	storageFile := tmpDir + "/test-snap-storage.bin"
-	snapshotStore := newPersistentSnapshotStorage(storageFile)
+	snapshotStore := NewSnapshotStorage(storageFile)
 
 	require.NoError(t, snapshotStore.Open())
 	require.NoError(t, snapshotStore.Replay())

--- a/storage.go
+++ b/storage.go
@@ -47,8 +47,8 @@ type persistentStorage struct {
 	file *os.File
 }
 
-// newPersistentStorage creates a new instance of persistentStorage with the provided path.
-func newPersistentStorage(path string) *persistentStorage {
+// NewStorage creates a new instance of Storage at the provided path.
+func NewStorage(path string) Storage {
 	return &persistentStorage{path: path}
 }
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -9,7 +9,7 @@ import (
 func TestPersistentStorageSetGet(t *testing.T) {
 	tmpDir := t.TempDir()
 	storageFile := tmpDir + "/test-storage.bin"
-	storage := newPersistentStorage(storageFile)
+	storage := NewStorage(storageFile)
 
 	require.NoError(t, storage.Open())
 

--- a/testing.go
+++ b/testing.go
@@ -143,7 +143,7 @@ func makeRaftArgs(t *testing.T, snapshotting bool, snapshotSize int) raftArgs {
 	tmpDir := t.TempDir()
 	id := "raft"
 	snapshotStorage := newPersistentSnapshotStorage(tmpDir + "/raft-snapshots")
-	log := newPersistentLog(tmpDir + "/raft-log")
+	log := NewLog(tmpDir + "/raft-log")
 	storage := newPersistentStorage(tmpDir + "/raft-storage")
 	stateMachine := newStateMachineMock(snapshotting, snapshotSize)
 	peers := make(map[string]Peer)

--- a/testing.go
+++ b/testing.go
@@ -161,12 +161,6 @@ func makeDefaultRaftArgs(t *testing.T, snapshotting bool, snapshotSize int) raft
 	}
 }
 
-type storagePaths struct {
-	logPath             string
-	storagePath         string
-	snapshotStoragePath string
-}
-
 type testCluster struct {
 	// The testing instance associated with the cluster.
 	t *testing.T

--- a/testing.go
+++ b/testing.go
@@ -130,37 +130,6 @@ func (s *stateMachineMock) NeedSnapshot() bool {
 	return s.snapshotting && len(s.operations)%s.snapshotSize == 0
 }
 
-type raftArgs struct {
-	id              string
-	log             Log
-	snapshotStorage SnapshotStorage
-	storage         Storage
-	stateMachine    StateMachine
-	peers           map[string]Peer
-	responseCh      chan<- OperationResponse
-}
-
-func makeDefaultRaftArgs(t *testing.T, snapshotting bool, snapshotSize int) raftArgs {
-	tmpDir := t.TempDir()
-	id := "raft"
-	snapshotStorage := NewSnapshotStorage(tmpDir + "/raft-snapshots")
-	log := NewLog(tmpDir + "/raft-log")
-	storage := NewStorage(tmpDir + "/raft-storage")
-	stateMachine := newStateMachineMock(snapshotting, snapshotSize)
-	peers := make(map[string]Peer)
-	responseCh := make(chan OperationResponse)
-
-	return raftArgs{
-		id:              id,
-		log:             log,
-		storage:         storage,
-		snapshotStorage: snapshotStorage,
-		peers:           peers,
-		stateMachine:    stateMachine,
-		responseCh:      responseCh,
-	}
-}
-
 type testCluster struct {
 	// The testing instance associated with the cluster.
 	t *testing.T

--- a/testing.go
+++ b/testing.go
@@ -636,6 +636,8 @@ func (tc *testCluster) restartServer(server int) {
 	snapshots := tc.servers[server].ListSnapshots()
 	if len(snapshots) > 0 {
 		tc.lastApplied[server] = snapshots[len(snapshots)-1].LastIncludedIndex
+	} else {
+		tc.lastApplied[server] = 0
 	}
 	tc.servers[server] = newServer
 	tc.operationResponses[server] = make(map[uint64]OperationResponse)

--- a/testing.go
+++ b/testing.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
+	"net"
 	"strconv"
 	"sync"
 	"testing"
@@ -35,14 +36,14 @@ func makeOperations(numOperations int) [][]byte {
 	return operations
 }
 
-func makePeerMaps(numServers int) []map[string]string {
-	clusterPeers := make([]map[string]string, numServers)
+func makePeerMaps(numServers int) []map[string]Peer {
+	clusterPeers := make([]map[string]Peer, numServers)
 	for i := 0; i < numServers; i++ {
-		clusterPeers[i] = make(map[string]string, numServers)
+		clusterPeers[i] = make(map[string]Peer, numServers)
 		for j := 0; j < numServers; j++ {
-			address := fmt.Sprintf("127.0.0.%d:8080", j)
 			peerID := fmt.Sprint(j)
-			clusterPeers[i][peerID] = address
+			peerAddr, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("127.0.0.%d:8080", j))
+			clusterPeers[i][peerID] = NewPeer(peerID, peerAddr)
 		}
 	}
 	return clusterPeers
@@ -139,12 +140,12 @@ type raftArgs struct {
 	responseCh      chan<- OperationResponse
 }
 
-func makeRaftArgs(t *testing.T, snapshotting bool, snapshotSize int) raftArgs {
+func makeDefaultRaftArgs(t *testing.T, snapshotting bool, snapshotSize int) raftArgs {
 	tmpDir := t.TempDir()
 	id := "raft"
-	snapshotStorage := newPersistentSnapshotStorage(tmpDir + "/raft-snapshots")
+	snapshotStorage := NewSnapshotStorage(tmpDir + "/raft-snapshots")
 	log := NewLog(tmpDir + "/raft-log")
-	storage := newPersistentStorage(tmpDir + "/raft-storage")
+	storage := NewStorage(tmpDir + "/raft-storage")
 	stateMachine := newStateMachineMock(snapshotting, snapshotSize)
 	peers := make(map[string]Peer)
 	responseCh := make(chan OperationResponse)
@@ -173,13 +174,24 @@ type testCluster struct {
 	// The servers making up the cluster.
 	servers []*Server
 
+	// The raft instances that make up the cluster.
+	rafts []*Raft
+
 	// The peers fore each server, where peers[i] is the peers
 	// for servers[i].
-	peers []map[string]string
+	peers []map[string]Peer
 
-	// The associated storage paths for each server, where
-	// paths[i] is the paths for servers[i].
-	paths []storagePaths
+	// The log associated with each server, where logs[i] is the
+	// log for servers[i]
+	logs []Log
+
+	// The snapshot storage associated with each server, where
+	// snapshotStore[i] is the snapshot storage for servers[i]
+	snapshotStores []SnapshotStorage
+
+	// The storage associated with each server, where stores[i] is the
+	// storage for servers[i]
+	stores []Storage
 
 	// The servers which are disconnected, where disconnected[i] being
 	// true indicates servers[i] is disconnected.
@@ -231,14 +243,17 @@ type testCluster struct {
 
 func newCluster(t *testing.T, numServers int, snapshotting bool, snapshotSize int) *testCluster {
 	servers := make([]*Server, numServers)
+	rafts := make([]*Raft, numServers)
+	logs := make([]Log, numServers)
+	snapshotStores := make([]SnapshotStorage, numServers)
+	stores := make([]Storage, numServers)
 	fsm := make([]*stateMachineMock, numServers)
-	replicateCh := make([]chan OperationResponse, numServers)
+	responseCh := make([]chan OperationResponse, numServers)
 	responses := make([]map[uint64]OperationResponse, numServers)
 	readOnlyResponseCh := make([]chan error, numServers)
 	serverErrors := make([]string, numServers)
 	lastApplied := make([]uint64, numServers)
 	disconnected := make([]bool, numServers)
-	paths := make([]storagePaths, numServers)
 
 	// The paths for all the persistent storage associated with the cluster.
 	tmpDir := t.TempDir()
@@ -249,31 +264,41 @@ func newCluster(t *testing.T, numServers int, snapshotting bool, snapshotSize in
 	// Make peer map for each server.
 	peers := makePeerMaps(numServers)
 
+	// Create the raft and server instances.
 	for i := 0; i < numServers; i++ {
-		replicateCh[i] = make(chan OperationResponse)
+		id := fmt.Sprint(i)
+		responseCh[i] = make(chan OperationResponse)
 		fsm[i] = newStateMachineMock(snapshotting, snapshotSize)
 		responses[i] = make(map[uint64]OperationResponse)
 		readOnlyResponseCh[i] = make(chan error, 1)
-		paths[i] = storagePaths{logPath: fmt.Sprintf(logFileFmt, i), storagePath: fmt.Sprintf(storageFileFmt, i),
-			snapshotStoragePath: fmt.Sprintf(snapshotFileFmt, i)}
-		id := fmt.Sprint(i)
+		logs[i] = NewLog(fmt.Sprintf(logFileFmt, i))
+		snapshotStores[i] = NewSnapshotStorage(fmt.Sprintf(storageFileFmt, i))
+		stores[i] = NewStorage(fmt.Sprintf(snapshotFileFmt, i))
 
-		server, err := NewServer(id, peers[i], fsm[i], paths[i].logPath, paths[i].storagePath, paths[i].snapshotStoragePath, replicateCh[i])
+		raft, err := NewRaft(id, peers[i], logs[i], stores[i], snapshotStores[i], fsm[i], responseCh[i])
 		if err != nil {
-			t.Fatalf("failed to create cluster server: server = %d, err = %s", i, err.Error())
+			t.Fatalf("failed to create raft instance: err = %s", err.Error())
 		}
+		rafts[i] = raft
 
+		server, err := NewServer(raft)
+		if err != nil {
+			t.Fatalf("failed to create server instance: err = %s", err.Error())
+		}
 		servers[i] = server
 	}
 
 	return &testCluster{
 		t:                  t,
 		servers:            servers,
+		rafts:              rafts,
 		disconnected:       disconnected,
 		peers:              peers,
-		paths:              paths,
+		logs:               logs,
+		snapshotStores:     snapshotStores,
+		stores:             stores,
 		fsm:                fsm,
-		responseCh:         replicateCh,
+		responseCh:         responseCh,
 		operationResponses: responses,
 		serverErrors:       serverErrors,
 		lastApplied:        lastApplied,
@@ -601,14 +626,23 @@ func (tc *testCluster) restartServer(server int) {
 	tc.responseCh[server] = make(chan OperationResponse)
 	tc.fsm[server] = newStateMachineMock(tc.snapshotting, tc.snapshotSize)
 
-	newServer, err := NewServer(serverID, tc.peers[server], tc.fsm[server], tc.paths[server].logPath,
-		tc.paths[server].storagePath, tc.paths[server].snapshotStoragePath, tc.responseCh[server])
+	newRaft, err := NewRaft(serverID, tc.peers[server], tc.logs[server], tc.stores[server], tc.snapshotStores[server],
+		tc.fsm[server], tc.responseCh[server])
 	if err != nil {
-		tc.t.Fatalf("failed to start cluster server: server = %d, err = %s", server, err.Error())
+		tc.t.Fatalf("failed to create raft instance: err = %s", err.Error())
 	}
+	tc.rafts[server] = newRaft
 
-	snapshot, _ := tc.servers[server].raft.snapshotStorage.LastSnapshot()
-	tc.lastApplied[server] = snapshot.LastIncludedIndex
+	newServer, err := NewServer(newRaft)
+	if err != nil {
+		tc.t.Fatalf("failed to create cluster server: err = %s", err.Error())
+	}
+	tc.servers[server] = newServer
+
+	snapshots := tc.servers[server].ListSnapshots()
+	if len(snapshots) > 0 {
+		tc.lastApplied[server] = snapshots[len(snapshots)-1].LastIncludedIndex
+	}
 	tc.servers[server] = newServer
 	tc.operationResponses[server] = make(map[uint64]OperationResponse)
 
@@ -622,7 +656,7 @@ func (tc *testCluster) restartServer(server int) {
 	}
 
 	for i := 0; i < len(tc.servers); i++ {
-		if err := tc.servers[i].raft.connectPeer(serverID); err != nil {
+		if err := tc.rafts[i].connectPeer(serverID); err != nil {
 			tc.t.Fatalf("error reconnecting peer: peer = %d, connectingTo = %d, err = %s", i, server, err.Error())
 		}
 	}
@@ -655,16 +689,19 @@ func (tc *testCluster) createPartition() {
 				if _, ok := partitionSet[j]; ok {
 					continue
 				}
-				if err := tc.servers[i].raft.disconnectPeer(fmt.Sprint(j)); err != nil {
-					tc.t.Fatalf("error disconnecting peer: peer = %d, disconnectingFrom = %d, err = %s", i, j, err.Error())
+				if err := tc.rafts[i].disconnectPeer(fmt.Sprint(j)); err != nil {
+					tc.t.Fatalf("error disconnecting peer: peer = %d, disconnectingFrom = %d, err = %s", i, j,
+						err.Error())
 				}
-				if err := tc.servers[j].raft.disconnectPeer(fmt.Sprint(i)); err != nil {
-					tc.t.Fatalf("error disconnecting peer: peer = %d, disconnectingFrom = %d, err = %s", j, i, err.Error())
+				if err := tc.rafts[j].disconnectPeer(fmt.Sprint(i)); err != nil {
+					tc.t.Fatalf("error disconnecting peer: peer = %d, disconnectingFrom = %d, err = %s", j, i,
+						err.Error())
 				}
 			}
 
-			if err := tc.servers[i].raft.disconnectPeer(fmt.Sprint(i)); err != nil {
-				tc.t.Fatalf("error disconnecting peer: peer = %d, disconnectingFrom = %d, err = %s", i, i, err.Error())
+			if err := tc.rafts[i].disconnectPeer(fmt.Sprint(i)); err != nil {
+				tc.t.Fatalf("error disconnecting peer: peer = %d, disconnectingFrom = %d, err = %s", i, i,
+					err.Error())
 			}
 		}
 	}
@@ -683,7 +720,7 @@ func (tc *testCluster) reconnectServer(server int) {
 	// Reconnect this server to itself. Note that this has no effect
 	// on the operation of the cluster. The only purpose of this is to
 	// indicate that this server is connected and should operate as expected.
-	if err := tc.servers[server].raft.disconnectPeer(serverID); err != nil {
+	if err := tc.rafts[server].disconnectPeer(serverID); err != nil {
 		tc.t.Fatalf("error reconnecting peer: peer = %d, connectingTo = %d, err = %s", server, server, err.Error())
 	}
 
@@ -691,10 +728,10 @@ func (tc *testCluster) reconnectServer(server int) {
 		if server == i {
 			continue
 		}
-		if err := tc.servers[i].raft.connectPeer(serverID); err != nil {
+		if err := tc.rafts[i].connectPeer(serverID); err != nil {
 			tc.t.Fatalf("error reconnecting peer: peer = %d, connectingTo = %d, err = %s", i, server, err.Error())
 		}
-		if err := tc.servers[server].raft.connectPeer(fmt.Sprint(i)); err != nil {
+		if err := tc.rafts[server].connectPeer(fmt.Sprint(i)); err != nil {
 			tc.t.Fatalf("error reconnecting peer: peer = %d, connectingTo = %d, err = %s", server, i, err.Error())
 		}
 	}
@@ -708,7 +745,7 @@ func (tc *testCluster) reconnectAllServers() {
 
 	for i := 0; i < len(tc.servers); i++ {
 		for j := 0; j < len(tc.servers); j++ {
-			if err := tc.servers[i].raft.connectPeer(fmt.Sprint(j)); err != nil {
+			if err := tc.rafts[i].connectPeer(fmt.Sprint(j)); err != nil {
 				tc.t.Fatalf("error reconnecting peer: peer = %d, connectingTo = %d, err = %s", i, j, err.Error())
 			}
 		}
@@ -729,7 +766,7 @@ func (tc *testCluster) disconnectServer(server int) {
 	// on the operation of the cluster. The only purpose of this is to
 	// indicate that this index is disconnected and will not operate
 	// as expected.
-	if err := tc.servers[server].raft.disconnectPeer(serverID); err != nil {
+	if err := tc.rafts[server].disconnectPeer(serverID); err != nil {
 		tc.t.Fatalf("error disconnecting peer: peer = %d, disconnectingFrom = %d, err = %s", server, server, err.Error())
 	}
 
@@ -737,10 +774,10 @@ func (tc *testCluster) disconnectServer(server int) {
 		if i == server {
 			continue
 		}
-		if err := tc.servers[i].raft.disconnectPeer(serverID); err != nil {
+		if err := tc.rafts[i].disconnectPeer(serverID); err != nil {
 			tc.t.Fatalf("error disconnecting peer: peer = %d, disconnectingFrom = %d, err = %s", i, server, err.Error())
 		}
-		if err := tc.servers[server].raft.disconnectPeer(fmt.Sprint(i)); err != nil {
+		if err := tc.rafts[server].disconnectPeer(fmt.Sprint(i)); err != nil {
 			tc.t.Fatalf("error disconnecting peer: peer = %d, disconnectingFrom = %d, err = %s", server, i, err.Error())
 		}
 	}


### PR DESCRIPTION
This includes both major and minor refinements of the `raft` package. The most important of these are the addition of the `Protocol` interface and that `NewServer` now accepts only a `Protocol` instance. The purpose of this change is to make the library more flexible - it allows the user to specify what `Log`, `Storage`, and `SnapshotStorage` implementation they wish to use while still using `Server`. Further, since `Server` accepts a `Protocol` instance, a user may use their own raft implementation as long as it satisfies the interface. 