### PR TITLE
Removed ListSnapshots from SnapshotStorage

### DIFF
--- a/options.go
+++ b/options.go
@@ -63,10 +63,6 @@ type options struct {
 	// the leader will send to the followers.
 	heartbeatInterval time.Duration
 
-	// The maximum number of log entries that will be transmitted via
-	// an AppendEntries RPC.
-	maxEntriesPerRPC int
-
 	// The duration that a lease remains valid upon renewal.
 	leaseDuration time.Duration
 

--- a/raft.go
+++ b/raft.go
@@ -148,10 +148,6 @@ type Protocol interface {
 	// install a snapshot and fills the response with the result of the installation. It returns an
 	// error if the snapshot installation process fails.
 	InstallSnapshot(request *InstallSnapshotRequest, response *InstallSnapshotResponse) error
-
-	// ListSnapshots returns a list of all snapshots currently stored by the protocol.
-	// Snapshots are used for log compaction and to bring new servers up to date.
-	ListSnapshots() []Snapshot
 }
 
 // Raft implements the Protocol interface. This implementation of Raft should be utilized as the internal
@@ -792,17 +788,6 @@ func (r *Raft) InstallSnapshot(
 	}
 
 	return nil
-}
-
-// ListSnapshots returns an array of all the snapshots that have been taken.
-func (r *Raft) ListSnapshots() []Snapshot {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	snapshots, err := r.snapshotStorage.ListSnapshots()
-	if err != nil {
-		r.options.logger.Fatalf("server %s failed while listing snapshots: %s", r.id, err.Error())
-	}
-	return snapshots
 }
 
 func (r *Raft) submitReplicatedOperation(

--- a/raft.go
+++ b/raft.go
@@ -377,12 +377,11 @@ func (r *Raft) Start() error {
 	go r.commitLoop()
 
 	r.options.logger.Infof(
-		"server %s started: electionTimeout = %v, heartbeatInterval = %v, leaseDuration = %v, maxLogEntriesPerRPC = %v",
+		"server %s started: electionTimeout = %v, heartbeatInterval = %v, leaseDuration = %v",
 		r.id,
 		r.options.electionTimeout,
 		r.options.heartbeatInterval,
 		r.options.leaseDuration,
-		r.options.maxEntriesPerRPC,
 	)
 
 	return nil

--- a/raft_test.go
+++ b/raft_test.go
@@ -438,11 +438,10 @@ func TestInstallSnapshotSuccess(t *testing.T) {
 	require.Equal(t, uint64(1), raft.lastIncludedIndex)
 	require.Equal(t, uint64(1), raft.lastIncludedTerm)
 
-	snapshots, err := raft.snapshotStorage.ListSnapshots()
+	snapshot, err := raft.snapshotStorage.LastSnapshot()
 	require.NoError(t, err)
-	require.NotNil(t, snapshots)
-	require.Len(t, snapshots, 1)
-	require.Equal(t, bytes, snapshots[0].Data)
+	require.NotNil(t, snapshot)
+	require.Equal(t, bytes, snapshot.Data)
 
 	// Make sure that the state machine was restored after installing the snapshot.
 	// The data from the snapshot from the state machine should match the data from the request.
@@ -492,11 +491,10 @@ func TestInstallSnapshotDiscardSuccess(t *testing.T) {
 	require.Equal(t, uint64(2), raft.lastIncludedIndex)
 	require.Equal(t, uint64(2), raft.lastIncludedTerm)
 
-	snapshots, err := raft.snapshotStorage.ListSnapshots()
+	snapshot, err := raft.snapshotStorage.LastSnapshot()
 	require.NoError(t, err)
-	require.NotNil(t, snapshots)
-	require.Len(t, snapshots, 1)
-	require.Equal(t, bytes, snapshots[0].Data)
+	require.NotNil(t, snapshot)
+	require.Equal(t, bytes, snapshot.Data)
 
 	require.Equal(t, uint64(2), raft.log.LastIndex())
 	require.Equal(t, uint64(2), raft.log.LastTerm())
@@ -559,11 +557,10 @@ func TestInstallSnapshotCompactSuccess(t *testing.T) {
 	require.Equal(t, uint64(3), raft.lastIncludedIndex)
 	require.Equal(t, uint64(1), raft.lastIncludedTerm)
 
-	snapshots, err := raft.snapshotStorage.ListSnapshots()
+	snapshot, err := raft.snapshotStorage.LastSnapshot()
 	require.NoError(t, err)
-	require.NotNil(t, snapshots)
-	require.Len(t, snapshots, 1)
-	require.Equal(t, bytes, snapshots[0].Data)
+	require.NotNil(t, snapshot)
+	require.Equal(t, bytes, snapshot.Data)
 
 	require.Equal(t, uint64(3), raft.log.LastIndex())
 	require.Equal(t, uint64(1), raft.log.LastTerm())
@@ -644,8 +641,7 @@ func TestInstallSnapshotOutOfDateTermFailure(t *testing.T) {
 	require.Equal(t, uint64(0), raft.lastIncludedIndex)
 	require.Equal(t, uint64(0), raft.lastIncludedTerm)
 
-	snapshots, err := raft.snapshotStorage.ListSnapshots()
+	snapshot, err := raft.snapshotStorage.LastSnapshot()
 	require.NoError(t, err)
-	require.NotNil(t, snapshots)
-	require.Len(t, snapshots, 0)
+	require.Nil(t, snapshot)
 }

--- a/server.go
+++ b/server.go
@@ -95,12 +95,6 @@ func (s *Server) SubmitOperation(
 	return s.raft.SubmitOperation(operation, operationType, timeout)
 }
 
-// ListSnapshots returns an array of all the snapshots that the underlying
-// Raft instance has taken.
-func (s *Server) ListSnapshots() []Snapshot {
-	return s.raft.ListSnapshots()
-}
-
 // AppendEntries handles the AppendEntries gRPC request.
 // It converts the request to the internal representation, invokes the AppendEntries function on the Raft instance,
 // and returns the response.

--- a/snapshot_storage.go
+++ b/snapshot_storage.go
@@ -91,9 +91,9 @@ func (p *persistentSnapshotStorage) Replay() error {
 
 	reader := bufio.NewReader(p.file)
 
-	var snapshot Snapshot
-	var err error
 	for {
+		var snapshot Snapshot
+		var err error
 		snapshot, err = decodeSnapshot(reader)
 		if err == io.EOF {
 			break

--- a/snapshot_storage.go
+++ b/snapshot_storage.go
@@ -91,8 +91,10 @@ func (p *persistentSnapshotStorage) Replay() error {
 
 	reader := bufio.NewReader(p.file)
 
+	var snapshot Snapshot
+	var err error
 	for {
-		snapshot, err := decodeSnapshot(reader)
+		snapshot, err = decodeSnapshot(reader)
 		if err == io.EOF {
 			break
 		}

--- a/snapshot_storage.go
+++ b/snapshot_storage.go
@@ -46,19 +46,14 @@ type SnapshotStorage interface {
 
 	// SaveSnapshot persists the provided snapshot.
 	SaveSnapshot(snapshot *Snapshot) error
-
-	// ListSnapshots returns an array of the snapshots that have been persisted.
-	// An error is returned if the snapshot storage is not open.
-	ListSnapshots() ([]Snapshot, error)
 }
 
 // persistentSnapshotStorage is an implementation of the SnapshotStorage interface. This
 // implementation is not concurrent safe.
 type persistentSnapshotStorage struct {
-	// All snapshots that have been persisted. This array is empty
-	// if no snapshots have been persisted or the storage has not
-	// been opened.
-	snapshots []Snapshot
+	// The most recently persisted snapshot if there is one
+	// and nil otherwise.
+	snapshot *Snapshot
 
 	// The path to where snapshots are persisted.
 	path string
@@ -85,7 +80,6 @@ func (p *persistentSnapshotStorage) Open() error {
 	}
 
 	p.file = file
-	p.snapshots = make([]Snapshot, 0)
 
 	return nil
 }
@@ -105,7 +99,7 @@ func (p *persistentSnapshotStorage) Replay() error {
 		if err != nil {
 			return errors.WrapError(err, "failed while replaying snapshot storage")
 		}
-		p.snapshots = append(p.snapshots, snapshot)
+		p.snapshot = &snapshot
 	}
 
 	return nil
@@ -119,7 +113,7 @@ func (p *persistentSnapshotStorage) Close() error {
 	if err := p.file.Close(); err != nil {
 		return errors.WrapError(err, "failed to close snapshot storage")
 	}
-	p.snapshots = nil
+	p.snapshot = nil
 	p.file = nil
 
 	return nil
@@ -129,17 +123,7 @@ func (p *persistentSnapshotStorage) LastSnapshot() (*Snapshot, error) {
 	if p.file == nil {
 		return nil, errSnapshotStoreNotOpen
 	}
-	if len(p.snapshots) == 0 {
-		return nil, nil
-	}
-	return &p.snapshots[len(p.snapshots)-1], nil
-}
-
-func (p *persistentSnapshotStorage) ListSnapshots() ([]Snapshot, error) {
-	if p.file == nil {
-		return p.snapshots, errSnapshotStoreNotOpen
-	}
-	return p.snapshots, nil
+	return p.snapshot, nil
 }
 
 func (p *persistentSnapshotStorage) SaveSnapshot(snapshot *Snapshot) error {
@@ -158,7 +142,7 @@ func (p *persistentSnapshotStorage) SaveSnapshot(snapshot *Snapshot) error {
 		return errors.WrapError(err, "failed to save snapshot")
 	}
 
-	p.snapshots = append(p.snapshots, *snapshot)
+	p.snapshot = snapshot
 
 	return nil
 }

--- a/snapshot_storage_test.go
+++ b/snapshot_storage_test.go
@@ -31,11 +31,6 @@ func TestSnapshotStore(t *testing.T) {
 	require.NotNil(t, last2)
 	validateSnapshot(t, snapshot2, last2)
 
-	snapshots, err := snapshotStore.ListSnapshots()
-	require.NoError(t, err)
-	require.NotNil(t, snapshots)
-	require.Len(t, snapshots, 2)
-
 	require.NoError(t, snapshotStore.Close())
 	require.NoError(t, snapshotStore.Open())
 	require.NoError(t, snapshotStore.Replay())
@@ -44,9 +39,4 @@ func TestSnapshotStore(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, last2)
 	validateSnapshot(t, snapshot2, last2)
-
-	snapshots, err = snapshotStore.ListSnapshots()
-	require.NoError(t, err)
-	require.NotNil(t, snapshots)
-	require.Len(t, snapshots, 2)
 }

--- a/testing.go
+++ b/testing.go
@@ -344,34 +344,6 @@ func (tc *testCluster) checkStateMachines(expectedMatches int, timeout time.Dura
 		}
 	}
 
-	for i := 0; i < len(appliedOperationsPerServer); i++ {
-		for j := 0; j < len(appliedOperationsPerServer); j++ {
-			applied1 := appliedOperationsPerServer[i]
-			applied2 := appliedOperationsPerServer[j]
-			if reflect.DeepEqual(applied1, applied2) {
-				continue
-			}
-			for k := 0; k < util.Min(len(applied1), len(applied2)); k++ {
-				op1 := applied1[k]
-				op2 := applied2[k]
-				if reflect.DeepEqual(op1, op2) {
-					continue
-				}
-				tc.t.Fatalf(
-					"fsm %d != fsm %d: index1 = %d term1 = %d op1 = %s index2 = %d term2 = %d op2 = %s",
-					i,
-					j,
-					op1.LogIndex,
-					op1.LogTerm,
-					string(op1.Bytes),
-					op2.LogIndex,
-					op2.LogTerm,
-					string(op2.Bytes),
-				)
-			}
-		}
-	}
-
 	tc.t.Fatalf("cluster state machines do not match")
 }
 


### PR DESCRIPTION
This removes the `ListSnapshots` function from the `SnapshotStorage` interface. Ultimately, this function was not actually needed by the raft implementation. I'd like to keep the interfaces in this project as minimal as possible, so I felt it was best to remove it rather than requiring that clients implement it if they are using their own `SnapshotStorage` implementation.