### PR TITLE
Made storage mechanisms optional parameters

### DIFF
--- a/options.go
+++ b/options.go
@@ -16,7 +16,7 @@ const (
 	defaultHeartbeat = time.Duration(50 * time.Millisecond)
 
 	minLeaseDuration     = time.Duration(25 * time.Millisecond)
-	maxLeaseDuration     = time.Duration(1000 * time.Millisecond)
+	maxLeaseDuration     = time.Duration(500 * time.Millisecond)
 	defaultLeaseDuration = time.Duration(100 * time.Millisecond)
 )
 
@@ -68,12 +68,24 @@ type options struct {
 
 	// A logger for debugging and important events.
 	logger Logger
+
+	// A provided log that can be used by raft.
+	log Log
+
+	// A provided state storage that can be used by raft.
+	stateStorage StateStorage
+
+	// A provided snapshot storage that can be used by raft.
+	snapshotStorage SnapshotStorage
+
+	// A provided network transport that can be used by raft.
+	transport Transport
 }
 
 // Option is a function that updates the options associated with Raft.
 type Option func(options *options) error
 
-// WithElectionTimeout sets the election timeout for the Raft server.
+// WithElectionTimeout sets the election timeout for raft.
 func WithElectionTimeout(time time.Duration) Option {
 	return func(options *options) error {
 		if time < minElectionTimeout || time > maxElectionTimeout {
@@ -85,7 +97,7 @@ func WithElectionTimeout(time time.Duration) Option {
 	}
 }
 
-// WithHeartbeatInterval sets the heartbeat interval for the Raft server.
+// WithHeartbeatInterval sets the heartbeat interval for raft.
 func WithHeartbeatInterval(time time.Duration) Option {
 	return func(options *options) error {
 		if time < minHeartbeat || time > maxHeartbeat {
@@ -98,10 +110,8 @@ func WithHeartbeatInterval(time time.Duration) Option {
 }
 
 // WithLeaseDuration sets the duration for which a lease remains valid upon
-// renewal. A longer lease duration generally corresponds to higher performance
-// of read-only operations but increases the likelihood that stale data is read.
-// Likewise, a shorter lease duration corresponds to lesser performance of read-only
-// operations but decreases the likelihood of stale data being read.
+// renewal. The lease should generally remain valid for a much smaller amount of
+// time than the election timeout.
 func WithLeaseDuration(leaseDuration time.Duration) Option {
 	return func(options *options) error {
 		if leaseDuration < minLeaseDuration || leaseDuration > maxLeaseDuration {
@@ -120,6 +130,54 @@ func WithLogger(logger Logger) Option {
 			return errors.New("logger must not be nil")
 		}
 		options.logger = logger
+		return nil
+	}
+}
+
+// WithLog sets the log that will be used by raft. This is useful
+// if you wish to use your own implementation of a log.
+func WithLog(log Log) Option {
+	return func(options *options) error {
+		if log == nil {
+			return errors.New("log must not be nil")
+		}
+		options.log = log
+		return nil
+	}
+}
+
+// WithStateStorage sets the state storage that will be used by raft.
+// This is useful if you wish to use your own implementation of a state storage.
+func WithStateStorage(stateStorage StateStorage) Option {
+	return func(options *options) error {
+		if stateStorage == nil {
+			return errors.New("state storage must not be nil")
+		}
+		options.stateStorage = stateStorage
+		return nil
+	}
+}
+
+// WithSnapshotStorage sets the snapshot storage that will be used by raft.
+// This is useful if you wish to use your own implementation of a snapshot storage.
+func WithSnapshotStorage(snapshotStorage SnapshotStorage) Option {
+	return func(options *options) error {
+		if snapshotStorage == nil {
+			return errors.New("snapshot storage must not be nil")
+		}
+		options.snapshotStorage = snapshotStorage
+		return nil
+	}
+}
+
+// WithTransport sets the network transport that will be used by raft.
+// This is useful if you wish to use your own implementation of a transport.
+func WithTransport(transport Transport) Option {
+	return func(options *options) error {
+		if transport == nil {
+			return errors.New("transport must not be nil")
+		}
+		options.transport = transport
 		return nil
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -53,7 +53,7 @@ func TestWithLeaseDuration(t *testing.T) {
 	require.NoError(t, WithLeaseDuration(500*time.Millisecond)(options))
 }
 
-// TestWithLogger checks that the logger option only accepts non-nil logs.
+// TestWithLogger checks that the logger option only accepts non-nil loggers.
 func TestWithLogger(t *testing.T) {
 	options := &options{}
 
@@ -64,4 +64,52 @@ func TestWithLogger(t *testing.T) {
 	testLogger, err := logger.NewLogger()
 	require.NoError(t, err)
 	require.NoError(t, WithLogger(testLogger)(options))
+}
+
+// TestWithLog checks that the log option only accepts non-nil logs.
+func TestWithLog(t *testing.T) {
+	options := &options{}
+
+	// Test nil input
+	require.Error(t, WithLog(nil)(options))
+
+	// Test valid input
+	log := &persistentLog{}
+	require.NoError(t, WithLog(log)(options))
+}
+
+// TestWithStateStorage checks that the state storage option only accepts non-nil state storage.
+func TestWithStateStorage(t *testing.T) {
+	options := &options{}
+
+	// Test nil input
+	require.Error(t, WithStateStorage(nil)(options))
+
+	// Test valid input
+	stateStore := &persistentStateStorage{}
+	require.NoError(t, WithStateStorage(stateStore)(options))
+}
+
+// TestWithSnapshotStorage checks that the snapshot storage option only accepts non-nil snapshot storage.
+func TestWithSnapshotStorage(t *testing.T) {
+	options := &options{}
+
+	// Test nil input
+	require.Error(t, WithSnapshotStorage(nil)(options))
+
+	// Test valid input
+	snapshotStore := &persistentSnapshotStorage{}
+	require.NoError(t, WithSnapshotStorage(snapshotStore)(options))
+}
+
+// TestWithTransport checks that the transport option only accepts non-nil transport.
+func TestWithTransport(t *testing.T) {
+	options := &options{}
+
+	// Test nil input
+	require.Error(t, WithTransport(nil)(options))
+
+	// Test valid input
+	transport := &transport{}
+	require.NoError(t, WithTransport(transport)(options))
 }

--- a/raft_test.go
+++ b/raft_test.go
@@ -12,26 +12,8 @@ import (
 func TestNewRaft(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	log, err := NewLog(tmpDir)
-	require.NoError(t, err)
-
-	snapshotStore, err := NewSnapshotStorage(tmpDir)
-	require.NoError(t, err)
-
-	stateStore, err := NewStateStorage(tmpDir)
-	require.NoError(t, err)
-
 	fsm := newStateMachineMock(false, 0)
-
-	raft, err := NewRaft(
-		"test-raft",
-		map[string]string{"test": "127.0.0.1:8080"},
-		nil,
-		log,
-		stateStore,
-		snapshotStore,
-		fsm,
-	)
+	raft, err := NewRaft("test", map[string]string{"test": "127.0.0.1:8080"}, fsm, tmpDir)
 	require.NoError(t, err)
 
 	require.Zero(t, raft.currentTerm)
@@ -40,6 +22,7 @@ func TestNewRaft(t *testing.T) {
 	require.Zero(t, raft.lastIncludedTerm)
 	require.Equal(t, "", raft.votedFor)
 	require.Equal(t, Shutdown, raft.state)
+	require.Equal(t, "test", raft.id)
 	require.NotNil(t, raft.operationManager)
 
 	require.Equal(t, defaultHeartbeat, raft.options.heartbeatInterval)


### PR DESCRIPTION
This PR makes the storage mechanisms and transport that raft uses optional. By default, the storage and transport that this package offers will be used. If the user wishes to use their own implementation, they may pass it as an option.