### PR TITLE
gRPC Fix

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -99,7 +99,7 @@ func (c *connectionManager) getClient(address string) (pb.RaftClient, error) {
 		return client, nil
 	}
 
-	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(c.creds))
+    conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(c.creds))
 	if err != nil {
 		return nil, fmt.Errorf("could not establish connection: %w", err)
 	}

--- a/transport.go
+++ b/transport.go
@@ -99,7 +99,7 @@ func (c *connectionManager) getClient(address string) (pb.RaftClient, error) {
 		return client, nil
 	}
 
-    conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(c.creds))
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(c.creds))
 	if err != nil {
 		return nil, fmt.Errorf("could not establish connection: %w", err)
 	}


### PR DESCRIPTION
This PR updates `transport.go` to use `grpc.NewClient` instead of `grpc.Dial`.